### PR TITLE
EditorConfig: [*.go]indent_style = tab

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,7 +11,7 @@ trim_trailing_whitespace = true
 
 # Go files
 [*.go]
-indent_style = space
+indent_style = tab
 indent_size = 2
 max_line_length = 120
 

--- a/main.go
+++ b/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-  "fmt"
+	"fmt"
 )
 
 func main() {
-  fmt.Println("Hello, World!")
+	fmt.Println("Hello, World!")
 }


### PR DESCRIPTION
The go language uses tab for indentation:

> Indentation
> We use tabs for indentation and gofmt emits them by default. Use spaces only if you must.

Source: https://go.dev/doc/effective_go#formatting